### PR TITLE
fix recursive watch node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "clean:client:dev:css": "rm -rf build/dev/client/css",
     "mkdir:client:dev:css": "mkdir -p build/dev/client/css",
     "build:client:dev:css": "run-s clean:client:dev:css mkdir:client:dev:css && node-sass --source-map true client/scss/index.scss build/dev/client/css/$npm_package_name.$npm_package_version.css",
-    "watch:client:dev:css": "run-s build:client:dev:css && NODE_ENV=development node-sass --source-map true -wr client/scss/index.scss build/dev/client/css/$npm_package_name.$npm_package_version.css",
+    "watch:client:dev:css": "run-s build:client:dev:css && NODE_ENV=development node-sass --source-map true -w -r client/scss/index.scss build/dev/client/css/$npm_package_name.$npm_package_version.css",
     "clean:client:dev:assets": "rm -rf build/dev/client/assets",
     "build:client:dev:assets": "run-s clean:client:dev:assets mkdir:client:dev && cp -r client/assets build/dev/client",
     "watch:client:dev:assets": "run-s build:client:dev:assets && chokidar client/assets/**/* -c 'npm run build:client:dev:assets'",


### PR DESCRIPTION
it appears `-wr` doesn't work but `-w -r` does.  The recursive option is not in effect otherwise, as tested by adding a second `scss` file, importing it into `index.scss`, then not seeing a rewrite occur when the second file is altered.
